### PR TITLE
Missing argument for "salesforce.client" service

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -46,9 +46,14 @@ services:
             - "@salesforce.http.client"
             - "@salesforce.client.url_generator"
             - "@salesforce.authentication.authenticator"
+            - "@salesforce.response_creator"
 
     salesforce.sobject_creator:
         class: GenesisGlobal\Salesforce\SalesforceBundle\Creator\SobjectCreator
+
+    salesforce.response_creator:
+        class: GenesisGlobal\Salesforce\Http\Response\ResponseCreator
+        private: true
 
     salesforce.service:
         class: GenesisGlobal\Salesforce\SalesforceBundle\Service\SalesforceService


### PR DESCRIPTION
Hi,

Thanks for your bundle, but i can use it to make a SOQL query.

One argument is missing for using the service "salesforce.client".

```
$client = $this->get('salesforce.client'); // Exception :(
```

This pull request is a fix ;)

Thanks !