### PR TITLE
Don't require a list of fields for getBySobjectId

### DIFF
--- a/src/Service/SalesforceService.php
+++ b/src/Service/SalesforceService.php
@@ -138,12 +138,15 @@ class SalesforceService implements SalesforceServiceInterface
     /**
      * @param $name
      * @param $id
-     * @param $fields
+     * @param $fields An array of fields to return. If not provided, all fields will be returned.
      * @return Response
      */
-    public function getBySobjectId($name, $id, $fields)
+    public function getBySobjectId($name, $id, $fields = [])
     {
-        $params = [ $id ] + [ 'fields' => $fields ];
+        $params = [ $id ];
+        if ($fields) {
+            $params += [ 'fields' => $fields ];
+        }
         $response = $this->client->get(
             $this->createAction($name, $params)
         );


### PR DESCRIPTION
If no fields are provided, the Salesforce API will return the sObject with all fields. As such, the parameter should be optional and not required.