### PR TITLE
Enable installation with symfony/flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "genesis-global/salesforce-bundle",
   "description": "Symfony bundle that provides OAuth2 authentication and exposes Salesforce REST API methods in OOP friendly way. ",
-  "type": "library",
+  "type": "symfony-bundle",
   "keywords": [ "salesforce"],
   "license": "MIT",
   "require": {


### PR DESCRIPTION
Symfony Flex requires bundles to have the type symfony-bundle, so we can automatically enable it.
We could probably go further and create a recipe for all the configuration, but this at least lets us use the bundle with symfony/flex