### PR TITLE
Avoid Symfony 4 deprecation on TreeBuilder::root

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,10 +17,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $root = $builder->root('salesforce');
+        $builder = new TreeBuilder('salesforce');
 
-        $root->addDefaultsIfNotSet()
+        // BC layer for symfony/config < 4.2
+        $rootNode = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('salesforce');
+
+        $rootNode->addDefaultsIfNotSet()
             ->children()
                 ->arrayNode('authentication')
                     ->isRequired()


### PR DESCRIPTION
Symfony 4.2 throws deprecations. Fix them while maintaing BC for <4.2
Thanks @ayrad