### PR TITLE
Extend Symfony compat to ^6.0 || ^7.0 || ^8.0; SF7 signatures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
   "keywords": [ "salesforce"],
   "license": "MIT",
   "require": {
-    "symfony/http-kernel": "^3.2|^4.0|^4.1|^5.0|^6.0",
-    "symfony/config": "^3.2|^4.0|^4.1|^5.0|^6.0",
-    "symfony/dependency-injection": "^3.2|^4.0|^4.1|^5.0|^6.0",
+    "symfony/http-kernel": "^6.0 || ^7.0 || ^8.0",
+    "symfony/config": "^6.0 || ^7.0 || ^8.0",
+    "symfony/dependency-injection": "^6.0 || ^7.0 || ^8.0",
     "genesis-global/salesforce": "^1.1.9"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.5"
+    "phpunit/phpunit": "^10.0 || ^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,12 +15,10 @@ class Configuration implements ConfigurationInterface
     /**
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('salesforce');
-
-        // BC layer for symfony/config < 4.2
-        $rootNode = \method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('salesforce');
+        $rootNode = $builder->getRootNode();
 
         $rootNode->addDefaultsIfNotSet()
             ->children()

--- a/tests/Service/SalesforceServiceTest.php
+++ b/tests/Service/SalesforceServiceTest.php
@@ -19,7 +19,7 @@ class SalesforceServiceTest extends \PHPUnit\Framework\TestCase
 
     protected $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = $this->createMock(SalesforceClientInterface::class);
         $this->parser = $this->createMock(ContentParserInterface::class);


### PR DESCRIPTION
- composer.json: widen symfony/* constraints to ^6.0 || ^7.0 || ^8.0, dropping legacy Symfony 3.x/4.x/5.x lower bound. PHP requirement unchanged. Bump phpunit dev dep to ^10.0 || ^11.0 so the suite runs on modern PHP.
- Configuration::getConfigTreeBuilder(): add : TreeBuilder return type required by SF7's ConfigurationInterface; remove dead pre-6 getRootNode()/root() BC shim.
- tests: setUp(): void for PHPUnit 10/11 compatibility.